### PR TITLE
Use queues when storing followers to the database;

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,16 @@ gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'twitter'
 gem 'dotenv-rails', groups: [:development, :test]
+gem 'sidekiq'
+gem 'sidekiq-scheduler'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
+end
+
+group :test do
+  gem 'rspec-sidekiq'
   gem 'webmock'
   gem 'vcr'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.7)
+    connection_pool (2.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -75,12 +76,18 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    e2mmap (0.1.0)
     equalizer (0.0.11)
     erubi (1.9.0)
+    et-orbi (1.2.4)
+      tzinfo
     ffi (1.13.1)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fugit (1.3.8)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -126,6 +133,7 @@ GEM
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
+    raabro (1.3.1)
     rack (2.2.3)
     rack-proxy (0.6.5)
       rack
@@ -161,6 +169,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.2)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.1)
@@ -177,7 +186,12 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
+    rspec-sidekiq (3.1.0)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.9.3)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -189,6 +203,17 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
+    sidekiq-scheduler (3.0.1)
+      e2mmap
+      redis (>= 3, < 5)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 3)
+      thwait
+      tilt (>= 1.4.0)
     simple_oauth (0.3.1)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
@@ -203,6 +228,8 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.0.1)
     thread_safe (0.3.6)
+    thwait (0.2.0)
+      e2mmap
     tilt (2.0.10)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -255,7 +282,10 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.3)
   rspec-rails
+  rspec-sidekiq
   sass-rails (>= 6)
+  sidekiq
+  sidekiq-scheduler
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+release: bundle exec rails db:migrate
+web: bundle exec rails server -p $PORT -e $RACK_ENV
+worker: bundle exec sidekiq -e $RACK_ENV -C config/sidekiq.yml

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,8 +13,7 @@ class UsersController < ApplicationController
   def view_followers
     begin
       @followers.each do |follower|
-        follower = Follower.find_or_create_by(username: follower.screen_name)
-        user.followers << follower unless user.followers.exists?(follower.id)
+        CreateFollowersWorker.perform_async(user.id, follower.screen_name)
       end
     rescue Twitter::Error::TooManyRequests => error
       @followers = []

--- a/app/workers/create_followers_worker.rb
+++ b/app/workers/create_followers_worker.rb
@@ -1,0 +1,17 @@
+class CreateFollowersWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: false
+
+  def perform(user_id, follower_username)
+    user = User.find(user_id)
+    follower = Follower.find_or_create_by(username: follower_username)
+
+    user.followers << follower unless follower_exists?(user, follower_username)
+  end
+
+  private
+
+  def follower_exists?(user, follower_username)
+    user.followers.where(username: follower_username).exists?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,16 @@
 Rails.application.routes.draw do
+  require 'sidekiq/web'
+
+  scope :monitoring do
+    # Sidekiq Basic Auth from routes on production environment
+    Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_AUTH_USERNAME"])) &
+        ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_AUTH_PASSWORD"]))
+    end if Rails.env.production?
+
+    mount Sidekiq::Web, at: '/sidekiq'
+  end
+
   post '/view_followers', to: 'users#view_followers'
   root to: 'users#index'
   resources :users

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,8 +5,18 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
-require 'support/vcr_setup'
+
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'support/vcr_setup'
+
+RSpec::Sidekiq.configure do |config|
+  # Clears all job queues before each example
+  config.clear_all_enqueued_jobs = true # default => true
+  # Whether to use terminal colours when outputting messages
+  config.enable_terminal_colours = true # default => true
+  # Warn when jobs are not enqueued to Redis but to a job array
+  config.warn_when_jobs_not_processed_by_sidekiq = false # default => true
+end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/workers/create_followers_spec.rb
+++ b/spec/workers/create_followers_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+require 'sidekiq/testing'
+Sidekiq::Testing.fake!
+
+RSpec.describe CreateFollowersWorker, type: :worker do
+  describe '#perform' do
+    it { is_expected.to be_processed_in :default }
+  end
+end


### PR DESCRIPTION
As we don't know how many followers might be stored, it could take a long time to process before the user sees anything.
Therefore to speed it up, I've implemented workers so that the database execution can be done in the background.