### PR TITLE
Add homepage note about stored users and followers.

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -22,6 +22,7 @@
   </p>
 
   <h3>Current users</h3>
+  <p>Click below to view the followers stored in the database for a given user:
   <% if @users.exists? %>
     <% @users.each do |user| %>
       <p><%= link_to user.username, user %></p>


### PR DESCRIPTION
Add a little note onto the home page to explain that to view stored users/followers in database, you need to click the username link on the home page.